### PR TITLE
Update codes in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,10 +73,10 @@ df2 = rdb("AMECO", "ZUTN", dimensions = Dict(:geo => ["ea12", "dnk"]));
 # or
 df2 = rdb("AMECO", "ZUTN", dimensions = (geo = ["ea12", "dnk"],));
 
-# Fetch several values of several dimensions from dataset 'Doing business' (DB) of World Bank :
-df3 = rdb("WB", "DB", dimensions = Dict(:country => ["DZ", "PE"], :indicator => ["ENF.CONT.COEN.COST.ZS", "IC.REG.COST.PC.FE.ZS"]));
+# Fetch several values of several dimensions from dataset 'Doing business' (DBS) of World Bank :
+df3 = rdb("WB", "DBS", dimensions = Dict(:country => ["DZA", "PER"], :frequency => ["A"], :indicator => ["ENF.CONT.COEN.COST.ZS", "IC.REG.COST.PC.FE.ZS"]));
 # or
-df3 = rdb("WB", "DB", dimensions = (country = ["DZ", "PE"], indicator = ["ENF.CONT.COEN.COST.ZS", "IC.REG.COST.PC.FE.ZS"]));
+df3 = rdb("WB", "DBS", dimensions = (country = ["DZA", "PER"], frequency = ["A"], indicator = ["ENF.CONT.COEN.COST.ZS", "IC.REG.COST.PC.FE.ZS"]));
 ```
 
 Fetch time series with a `query`:
@@ -90,12 +90,12 @@ df2 = rdb("IMF", "WEO:2019-10", query = "current account balance percent");
 
 Fetch one series from the dataset 'Doing Business' of WB provider with the link:
 ```julia
-df1 = rdb(api_link = "https://api.db.nomics.world/v22/series/WB/DB?dimensions=%7B%22country%22%3A%5B%22FR%22%2C%22IT%22%2C%22ES%22%5D%7D&q=IC.REG.PROC.FE.NO&observations=1&format=json&align_periods=1&offset=0&facets=0");
+df1 = rdb(api_link = "https://api.db.nomics.world/v22/series/WB/DBS?dimensions=%7B%22country%22%3A%5B%22FRA%22%2C%22ITA%22%2C%22ESP%22%5D%7D&q=IC.REG.PROC.FE.NO&observations=1&format=json&align_periods=1&offset=0&facets=0");
 ```
 
 In the event that you only use the argument `api_link`, you can drop the name and run:
 ```julia
-df1 = rdb("https://api.db.nomics.world/v22/series/WB/DB?dimensions=%7B%22country%22%3A%5B%22FR%22%2C%22IT%22%2C%22ES%22%5D%7D&q=IC.REG.PROC.FE.NO&observations=1&format=json&align_periods=1&offset=0&facets=0");
+df1 = rdb("https://api.db.nomics.world/v22/series/WB/DBS?dimensions=%7B%22country%22%3A%5B%22FRA%22%2C%22ITA%22%2C%22ESP%22%5D%7D&q=IC.REG.PROC.FE.NO&observations=1&format=json&align_periods=1&offset=0&facets=0");
 ```
 
 Fetch the available datasets of a provider


### PR DESCRIPTION
The World Bank fetcher was updated recently, downloading data from the new web API of the World Bank.

This has lead to dataset code changes (e.g. `DB` => `DBS`), country code changes from 2 to 3 letters (e.g. `FR` => `FRA`).
Besides, a new dimension named "frequency" was introduced because some datasets now provide series using different frequencies.

See also this related post on the forum: https://dbnomics.discourse.group/t/embi-data-availability/584/9

As the README of DBnomics.jl mentions some datasets of the World Bank, here is an update.

However, I did not test it (mainly because I don't use Julia daily).